### PR TITLE
(Branch) Use strategy pattern for ExpressionNode functionality

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -30,6 +30,7 @@ import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.lib.tag.TagLibrary;
 import com.hubspot.jinjava.lib.tag.eager.EagerToken;
+import com.hubspot.jinjava.tree.ExpressionNode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.DeferredValueUtils;
 import com.hubspot.jinjava.util.ScopeMap;
@@ -85,6 +86,7 @@ public class Context extends ScopeMap<String, Object> {
   private final FilterLibrary filterLibrary;
   private final FunctionLibrary functionLibrary;
   private final TagLibrary tagLibrary;
+  private Class<? extends ExpressionNode> expressionNodeClass = ExpressionNode.class;
 
   private final Context parent;
 
@@ -164,6 +166,8 @@ public class Context extends ScopeMap<String, Object> {
     this.tagLibrary = new TagLibrary(parent == null, disabled.get(Library.TAG));
     this.functionLibrary =
       new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
+    this.expressionNodeClass =
+      parent == null ? ExpressionNode.class : parent.expressionNodeClass;
   }
 
   public void reset() {
@@ -472,6 +476,16 @@ public class Context extends ScopeMap<String, Object> {
 
   public void registerTag(Tag t) {
     tagLibrary.addTag(t);
+  }
+
+  public Class<? extends ExpressionNode> getExpressionNodeClass() {
+    return expressionNodeClass;
+  }
+
+  public void setExpressionNodeClass(
+    Class<? extends ExpressionNode> expressionNodeClass
+  ) {
+    this.expressionNodeClass = expressionNodeClass;
   }
 
   public CallStack getExtendPathStack() {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -20,6 +20,8 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
+import com.hubspot.jinjava.lib.expression.DefaultExpressionStrategy;
+import com.hubspot.jinjava.lib.expression.ExpressionStrategy;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.lib.exptest.ExpTestLibrary;
 import com.hubspot.jinjava.lib.filter.Filter;
@@ -30,7 +32,6 @@ import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.lib.tag.TagLibrary;
 import com.hubspot.jinjava.lib.tag.eager.EagerToken;
-import com.hubspot.jinjava.tree.ExpressionNode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.DeferredValueUtils;
 import com.hubspot.jinjava.util.ScopeMap;
@@ -86,7 +87,7 @@ public class Context extends ScopeMap<String, Object> {
   private final FilterLibrary filterLibrary;
   private final FunctionLibrary functionLibrary;
   private final TagLibrary tagLibrary;
-  private Class<? extends ExpressionNode> expressionNodeClass = ExpressionNode.class;
+  private ExpressionStrategy expressionStrategy = new DefaultExpressionStrategy();
 
   private final Context parent;
 
@@ -166,8 +167,9 @@ public class Context extends ScopeMap<String, Object> {
     this.tagLibrary = new TagLibrary(parent == null, disabled.get(Library.TAG));
     this.functionLibrary =
       new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
-    this.expressionNodeClass =
-      parent == null ? ExpressionNode.class : parent.expressionNodeClass;
+    if (parent != null) {
+      this.expressionStrategy = parent.expressionStrategy;
+    }
   }
 
   public void reset() {
@@ -478,14 +480,12 @@ public class Context extends ScopeMap<String, Object> {
     tagLibrary.addTag(t);
   }
 
-  public Class<? extends ExpressionNode> getExpressionNodeClass() {
-    return expressionNodeClass;
+  public ExpressionStrategy getExpressionStrategy() {
+    return expressionStrategy;
   }
 
-  public void setExpressionNodeClass(
-    Class<? extends ExpressionNode> expressionNodeClass
-  ) {
-    this.expressionNodeClass = expressionNodeClass;
+  public void setExpressionStrategy(ExpressionStrategy expressionStrategy) {
+    this.expressionStrategy = expressionStrategy;
   }
 
   public CallStack getExtendPathStack() {

--- a/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
@@ -1,0 +1,46 @@
+package com.hubspot.jinjava.lib.expression;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.filter.EscapeFilter;
+import com.hubspot.jinjava.objects.SafeString;
+import com.hubspot.jinjava.tree.output.RenderedOutputNode;
+import com.hubspot.jinjava.tree.parse.ExpressionToken;
+import com.hubspot.jinjava.util.Logging;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+
+public class DefaultExpressionStrategy implements ExpressionStrategy {
+
+  public RenderedOutputNode interpretOutput(
+    ExpressionToken master,
+    JinjavaInterpreter interpreter
+  ) {
+    Object var = interpreter.resolveELExpression(
+      master.getExpr(),
+      master.getLineNumber()
+    );
+    String result = Objects.toString(var, "");
+
+    if (interpreter.getConfig().isNestedInterpretationEnabled()) {
+      if (
+        !StringUtils.equals(result, master.getImage()) &&
+        (
+          StringUtils.contains(result, master.getSymbols().getExpressionStart()) ||
+          StringUtils.contains(result, master.getSymbols().getExpressionStartWithTag())
+        )
+      ) {
+        try {
+          result = interpreter.renderFlat(result);
+        } catch (Exception e) {
+          Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
+        }
+      }
+    }
+
+    if (interpreter.getContext().isAutoEscape() && !(var instanceof SafeString)) {
+      result = EscapeFilter.escapeHtmlEntities(result);
+    }
+
+    return new RenderedOutputNode(result);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -1,0 +1,16 @@
+package com.hubspot.jinjava.lib.expression;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.output.RenderedOutputNode;
+import com.hubspot.jinjava.tree.parse.ExpressionToken;
+
+public class EagerExpressionStrategy implements ExpressionStrategy {
+
+  @Override
+  public RenderedOutputNode interpretOutput(
+    ExpressionToken master,
+    JinjavaInterpreter interpreter
+  ) {
+    return null; // TODO replace with actual functionality
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/expression/ExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/ExpressionStrategy.java
@@ -1,0 +1,12 @@
+package com.hubspot.jinjava.lib.expression;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.output.RenderedOutputNode;
+import com.hubspot.jinjava.tree.parse.ExpressionToken;
+
+public interface ExpressionStrategy {
+  RenderedOutputNode interpretOutput(
+    ExpressionToken master,
+    JinjavaInterpreter interpreter
+  );
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -22,14 +22,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     try {
       return tag.interpret(tagNode, interpreter);
     } catch (DeferredValueException e) {
-      if (interpreter.getConfig().isEagerExecutionEnabled()) {
-        return wrapInAutoEscapeIfNeeded(
-          eagerInterpret(tagNode, interpreter),
-          interpreter
-        );
-      } else {
-        throw e;
-      }
+      return wrapInAutoEscapeIfNeeded(eagerInterpret(tagNode, interpreter), interpreter);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.mode;
 
 import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.lib.expression.EagerExpressionStrategy;
 import com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator;
 import com.hubspot.jinjava.lib.tag.eager.EagerTagFactory;
 import java.util.Optional;
@@ -21,6 +22,6 @@ public class EagerExecutionMode implements ExecutionMode {
       .map(tag -> EagerTagFactory.getEagerTagDecorator(tag.getClass()))
       .filter(Optional::isPresent)
       .forEach(maybeEagerTag -> context.registerTag(maybeEagerTag.get()));
-    // TODO prepare expression node
+    context.setExpressionStrategy(new EagerExpressionStrategy());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -166,9 +166,22 @@ public class TreeParser {
   }
 
   private Node expression(ExpressionToken expressionToken) {
-    ExpressionNode n = new ExpressionNode(expressionToken);
+    ExpressionNode n = createExpressionNode(expressionToken);
     n.setParent(parent);
     return n;
+  }
+
+  private ExpressionNode createExpressionNode(ExpressionToken expressionToken) {
+    try {
+      return interpreter
+        .getContext()
+        .getExpressionNodeClass()
+        .getDeclaredConstructor(ExpressionToken.class)
+        .newInstance(expressionToken);
+    } catch (ReflectiveOperationException e) {
+      interpreter.addError(TemplateError.fromException(e));
+      return new ExpressionNode(expressionToken);
+    }
   }
 
   private Node tag(TagToken tagToken) {

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -172,16 +172,10 @@ public class TreeParser {
   }
 
   private ExpressionNode createExpressionNode(ExpressionToken expressionToken) {
-    try {
-      return interpreter
-        .getContext()
-        .getExpressionNodeClass()
-        .getDeclaredConstructor(ExpressionToken.class)
-        .newInstance(expressionToken);
-    } catch (ReflectiveOperationException e) {
-      interpreter.addError(TemplateError.fromException(e));
-      return new ExpressionNode(expressionToken);
-    }
+    return new ExpressionNode(
+      interpreter.getContext().getExpressionStrategy(),
+      expressionToken
+    );
   }
 
   private Node tag(TagToken tagToken) {

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -36,11 +37,7 @@ public class ExpectedTemplateInterpreter {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,
       jinjava.getGlobalContextCopy(),
-      JinjavaConfig
-        .newBuilder()
-        .withPreserveForFinalPass(false)
-        .withEagerExecutionEnabled(false)
-        .build()
+      JinjavaConfig.newBuilder().withExecutionMode(new DefaultExecutionMode()).build()
     );
     try {
       JinjavaInterpreter.pushCurrent(preserveInterpreter);


### PR DESCRIPTION
Part of https://github.com/HubSpot/jinjava/issues/532
---
Introducing the strategy pattern into the ExpressionNode, similar to how it works in the TagNode, allows for the interpretation functionality to not be coupled directly to the concept of an ExpressionNode. This allows for different approaches or strategies to interpreting an ExpressionNode.

For Eager Execution, the ExpressionNode needs to be interpreted slightly differently so rather than adding multiple approaches in the ExpressionNode class, it is better to abstract the functionality into this new `interface ExpressionStrategy`.

There is a DefaultExpressionStrategy for the current ExpressionNode's functionality, and there is a skeleton added for the functionality that will be used when performing eager execution, called EagerExpressionStrategy.